### PR TITLE
修改上次PR错误包含的部分编辑、增加hook概念以便在镜像之外存储个人修改

### DIFF
--- a/.github/workflows/UpdateDockerOnly.yml
+++ b/.github/workflows/UpdateDockerOnly.yml
@@ -36,8 +36,8 @@ jobs:
           context: .
           push: true
           file: Dockerfile
-          tags: morzlee/l4d2:latest
-          cache-from: type=registry,ref=morzlee/l4d2:latest
+          tags: rosmeowtis/anne:latest
+          cache-from: type=registry,ref=rosmeowtis/anne:latest
           cache-to: type=inline
           build-args: |
             NEEDUPDATE=${{ env.NEEDUPDATE }}

--- a/.github/workflows/UpdateDockerOnly.yml
+++ b/.github/workflows/UpdateDockerOnly.yml
@@ -35,8 +35,8 @@ jobs:
         with:
           push: true
           file: Dockerfile
-          tags: rosmeowtis/anne:latest
-          cache-from: type=registry,ref=rosmeowtis/anne:latest
+          tags: morzlee/l4d2:latest
+          cache-from: type=registry,ref=morzlee/l4d2:latest
           cache-to: type=inline
           build-args: |
             NEEDUPDATE=${{ env.NEEDUPDATE }}

--- a/.github/workflows/UpdateDockerOnly.yml
+++ b/.github/workflows/UpdateDockerOnly.yml
@@ -33,7 +33,6 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v5
         with:
-          context: .
           push: true
           file: Dockerfile
           tags: rosmeowtis/anne:latest

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -33,8 +33,8 @@ jobs:
         with:
           push: true
           file: Dockerfile
-          tags: rosmeowtis/anne:latest
-          cache-from: type=registry,ref=rosmeowtis/anne:latest
+          tags: morzlee/l4d2:latest
+          cache-from: type=registry,ref=morzlee/l4d2:latest
           cache-to: type=inline
           build-args: |
             NEEDUPDATE=${{ env.NEEDUPDATE }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -34,8 +34,8 @@ jobs:
           context: .
           push: true
           file: Dockerfile
-          tags: morzlee/l4d2:latest
-          cache-from: type=registry,ref=morzlee/l4d2:latest
+          tags: rosmeowtis/anne:latest
+          cache-from: type=registry,ref=rosmeowtis/anne:latest
           cache-to: type=inline
           build-args: |
             NEEDUPDATE=${{ env.NEEDUPDATE }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -31,7 +31,6 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v5
         with:
-          context: .
           push: true
           file: Dockerfile
           tags: rosmeowtis/anne:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,4 +68,4 @@ ENV PORT=2333 \
 
 
 COPY --chown=louis:louis ./entrypoints /home/louis/
-ENTRYPOINT ["sh", "main.sh"]
+ENTRYPOINT ["/bin/bash", "entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     container_name: anne1
     # 必须采用 host 模式，然后在环境变量中指定端口，否则连接不上
     network_mode: host
-    image: rosmeowtis/anne
+    image: morzlee/l4d2
     build:
       context: .
       dockerfile: Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     container_name: anne1
     # 必须采用 host 模式，然后在环境变量中指定端口，否则连接不上
     network_mode: host
-    image: morzlee/l4d2
+    image: rosmeowtis/anne
     build:
       context: .
       dockerfile: Dockerfile

--- a/entrypoints/entrypoint.sh
+++ b/entrypoints/entrypoint.sh
@@ -1,5 +1,5 @@
-sh ./refresh-addons.sh
-[ -e ./enthooks/pre-init.sh ] && sh ./enthooks/pre-init.sh || echo "[Rosmeowtis]: skip pre-init hook"
-sh ./init-plugins.sh
-[ -e ./enthooks/post-init.sh ] && sh ./enthooks/post-init.sh || echo "[Rosmeowtis]: skip post-init hook"
-sh ./run.sh
+bash ./refresh-addons.sh
+[ -e ./enthooks/pre-init.sh ] && bash ./enthooks/pre-init.sh || echo "[Rosmeowtis]: skip pre-init hook"
+bash ./init-plugins.sh
+[ -e ./enthooks/post-init.sh ] && bash ./enthooks/post-init.sh || echo "[Rosmeowtis]: skip post-init hook"
+bash ./run.sh

--- a/entrypoints/entrypoint.sh
+++ b/entrypoints/entrypoint.sh
@@ -1,0 +1,5 @@
+sh ./refresh-addons.sh
+[ -e ./enthooks/pre-init.sh ] && sh ./enthooks/pre-init.sh || echo "[Rosmeowtis]: skip pre-init hook"
+sh ./init-plugins.sh
+[ -e ./enthooks/post-init.sh ] && sh ./enthooks/post-init.sh || echo "[Rosmeowtis]: skip post-init hook"
+sh ./run.sh

--- a/entrypoints/init-plugins.sh
+++ b/entrypoints/init-plugins.sh
@@ -3,8 +3,6 @@
 # $(pwd) = /home/louis
 
 main() {
-	sh ./refresh-addons.sh
-
 	# plugins Config
 	if [ ! -d "/home/louis/l4d2/left4dead2/addons/sourcemod/" ]; then
 		if [ "$plugin" = "anne" ]; then
@@ -165,10 +163,8 @@ main() {
 		rm /home/louis/l4d2/left4dead2/*motd.txt
 		rm /home/louis/l4d2/left4dead2/*host.txt
 	fi
-
-	# Start Game
-	cd l4d2 && ./srcds_run -console -game left4dead2 -ip 0.0.0.0 -tickrate 100 -port "$PORT" +maxplayers "$PLAYERS" +map "$MAP" -secure
 }
+
 oldpluginpackage() {
 	echo -e "\n\"$steamid\" \"99:z\"" >>/home/louis/l4d2/left4dead2/addons/sourcemod/configs/admins_simple.ini
 	echo "sv_steamgroup \"$steamgroup\"" >>/home/louis/l4d2/left4dead2/cfg/server.cfg

--- a/entrypoints/refresh-addons.sh
+++ b/entrypoints/refresh-addons.sh
@@ -14,4 +14,4 @@ for i in $(ls /sm_configs); do
     ln -sf /sm_configs/$i l4d2/left4dead2/addons/
 done
 
-echo "[Init] 刷新了 l4d2/left4dead2/addons 中的软连接
+echo "[Init] 刷新了 l4d2/left4dead2/addons 中的软连接"

--- a/entrypoints/run.sh
+++ b/entrypoints/run.sh
@@ -1,0 +1,1 @@
+cd l4d2 && ./srcds_run -console -game left4dead2 -ip 0.0.0.0 -tickrate 100 -port "$PORT" +maxplayers "$PLAYERS" +map "$MAP" -secure

--- a/examples/anneht/docker-compose.yml
+++ b/examples/anneht/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     container_name: anne1
     # 必须采用 host 模式，然后在环境变量中指定端口，否则连接不上
     network_mode: host
-    image: rosmeowtis/anne:hunters
+    image: morzlee/l4d2:hunters
     build:
       context: .
       dockerfile: ../../Dockerfile

--- a/examples/anneht/docker-compose.yml
+++ b/examples/anneht/docker-compose.yml
@@ -1,0 +1,49 @@
+version: "3.8"
+services:
+  anne1:
+    container_name: anne1
+    # 必须采用 host 模式，然后在环境变量中指定端口，否则连接不上
+    network_mode: host
+    image: rosmeowtis/anne:hunters
+    build:
+      context: .
+      dockerfile: ../../Dockerfile
+      args:
+        NEEDUPDATE: "no"
+        # NEEDUPDATE: $(date +%s)
+    environment:
+      # 选择哪个插件组，zone是现在的Anne+Zonemod整合包
+      plugin: "zone"
+      # 按云服配置，不限帧（否则限帧150）
+      cloud: "true"
+      # 东8区
+      TZ: "Asia/Shanghai"
+      # Steam 地区，4 表示亚洲，可决定此服务器在 openserverbrowser 中的分类和匹配玩家来源
+      REGION: 4
+      # rcon密码
+      password: "123456"
+      # mysql配置，如果没有数据库则留空
+      mysqlexist: "false"
+      mysql: ""
+      mysqlport: ""
+      mysqluser: ""
+      mysqlpassword: ""
+      # 初始超管
+      steamid: ""
+      # 崩溃报告上传网站需要的账号
+      steamid64: ""
+      steamgroup: ""
+      # 绑定端口，由于是 host 网络模式，这里的端口就是主机的端口
+      PORT: 27001
+      # 设置服务器名称
+      hostname: "Anne测试服#1"
+      # 把默认地图设成闪电突袭2（需要服务器 /keep/maps 下面有对应的vpk）
+      # MAP: "l4d2_stadium1_apartment"
+      # 如果没装三方图就用下面的替代
+      MAP: "c3m1_plankcountry"
+    volumes:
+      - "./enthooks:/home/louis/enthooks"
+      # - "/keep/maps:/map"
+      # 宿主机上的路径:容器中的路径
+      # - "/keep/maps:/map"
+      # - "/keep/sm_configs:/sm_configs"

--- a/examples/anneht/enthooks/post-init.sh
+++ b/examples/anneht/enthooks/post-init.sh
@@ -1,0 +1,35 @@
+# 1. 向 hunters.cfg 中插入默认 0 秒和开回血配置
+SRCDIR=${HOME}/enthooks
+CFGDIR=${HOME}/l4d2/left4dead2/cfg/cfgogl/hunters
+CMD1='confogl_addcvar versus_special_respawn_interval 0'
+CMD2='confogl_addcvar ReturnBlood 1'
+cd ${CFGDIR}
+if [ $( cat hunters.cfg | grep "^${CMD1}" || echo "0" ) = "0" ]; then
+  echo -e "\n${CMD1}" >> hunters.cfg
+  echo "[Rosmeowtis]: 插入 ${CMD1}"
+fi
+if [ $( cat hunters.cfg | grep "^${CMD2}" || echo "0" ) = "0" ]; then
+  echo -e "\n${CMD2}" >> hunters.cfg
+  echo "[Rosmeowtis]: 插入 ${CMD2}"
+fi
+cd -
+
+# 2. 替换 !match 指令，只保留ht训练和单人装逼
+
+cat <<EOF > ${HOME}/l4d2/left4dead2/addons/sourcemod/configs/matchmodes.txt
+"MatchModes"
+{
+        "AnneHappy Configs"
+        {
+                "hunters"
+                {
+                        "name" "1vHT模式"
+                }
+                "alone"
+                {
+                        "name" "单人装逼模式"
+                }
+        }
+}
+EOF
+echo "[Rosmeowtis]: 已替换 1vHT 默认配置(2t0s开回血)"


### PR DESCRIPTION
1、上次PR误解了sh 和 bash 的功能，使得初始化脚本出现异常，此次将用到shell统一改为bash
2、从 github action 参数中删除了 context，使其能正常寻找到构建脚本
3、增加了 hooks 概念，可以在entrypoint安装完插件后、运行游戏前对容器进行调整，并提供了示例脚本。